### PR TITLE
rewrite merge_config

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -112,9 +112,8 @@ endif()
 if(CREATE_NEW_DOTCONFIG)
   execute_process(
     COMMAND
+    ${PYTHON_EXECUTABLE}
     ${PROJECT_SOURCE_DIR}/scripts/kconfig/merge_config.py
-    -m
-    -q
     -O ${PROJECT_BINARY_DIR}
     ${merge_config_files}
     WORKING_DIRECTORY ${APPLICATION_SOURCE_DIR}


### PR DESCRIPTION
Rewrite of merge_config.py, several unrelated changes including;

Do not attribute meaning to lines that look like this:
\# CONFIG_SPI=y

Only to lines that look like this:
\# CONFIG_SPI is not set

Removed the unimplemented 'runmake' and 'alltarget' arguments.

Invoke the python interpreter instead of the script directly to avoid
reliance on bash's shebang feature.

Use exact line match instead of substring to detect redundant
config's.

And more ...

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>