### PR TITLE
tests: benchmarks: interrupt_latency: fix build, outlier metric and trigger race

### DIFF
--- a/subsys/testsuite/ztest/benchmark/Kconfig
+++ b/subsys/testsuite/ztest/benchmark/Kconfig
@@ -45,13 +45,14 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  characterised by how bad an individual operation can be, and
 	  that lives in the tail of the distribution.
 
-	  The percentiles also give the report its outlier count, the number of samples slower
-	  than the median. For a kernel latency distribution that is the number of runs that were
-	  disturbed, which is what the human-readable report carries instead of a standard error:
-	  these distributions are a baseline plus a few interrupted runs rather than samples of one
-	  stochastic population, and quoting how precisely their average was estimated suggests an
-	  average that no single execution ever produced. The standard error stays in the CSV
-	  output, whose columns are fixed.
+	  The percentiles also give the report its outlier count, the number of samples that exceed
+	  the median by more than a margin. For a kernel latency distribution that is the number of
+	  runs that were disturbed, which is what the human-readable report carries instead of a
+	  standard error: these distributions are a baseline plus a few interrupted runs rather than
+	  samples of one stochastic population, and quoting how precisely their average was
+	  estimated suggests an average that no single execution ever produced. The standard error
+	  stays in the CSV output, whose columns are fixed. See
+	  CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV for why the margin is needed.
 
 	  A percentile needs enough samples to be resolved at all. p99
 	  needs at least 100, p99.9 at least 1000 and p99.99 at least
@@ -59,6 +60,29 @@ config ZTEST_BENCHMARK_PERCENTILES
 	  maximum. Retaining samples costs 8 bytes each, so the buffer
 	  has to be sized for the number of iterations the benchmarks
 	  run.
+
+config ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV
+	int "Outlier margin above the median, as a divisor"
+	depends on ZTEST_BENCHMARK_PERCENTILES
+	default 16
+	range 1 1000
+	help
+	  How far above the median a sample has to sit before it counts as
+	  an outlier, expressed as a divisor of the median: the default of
+	  16 sets the margin at a sixteenth of the median, so a baseline of
+	  400 counts a sample from 426 upwards. The margin is never less
+	  than two counts, so that a distribution spanning only adjacent
+	  counts of a coarse timer never registers.
+
+	  Without a margin every sample above the median counts, and the
+	  baseline of a benchmark is not one exact value: the resolution of
+	  the timing counter spreads it over a few counts, and where that
+	  counter is coarse relative to the operation being measured the
+	  whole distribution can span as little as two values. Half the
+	  samples then land above the median and are reported as outliers
+	  although nothing disturbed them. Lower this to count smaller
+	  disturbances, raise it on a platform whose baseline is noisy by
+	  nature.
 
 config ZTEST_BENCHMARK_MAX_SAMPLES
 	int "Number of samples retained for percentiles"

--- a/subsys/testsuite/ztest/benchmark/src/benchmark.c
+++ b/subsys/testsuite/ztest/benchmark/src/benchmark.c
@@ -44,6 +44,10 @@ static void printk_line(const char *fn, char sep_char)
  * The correction is a real number, so the corrected values are real
  * numbers too, and generally do not coincide with any single
  * measurement.
+ *
+ * A negative result is not clamped: it means the operation costs less
+ * than the control loop bracketing it, so the counter is too coarse to
+ * measure it. Clamping would hide that behind a plausible number.
  */
 static double noise_correction(double value, double ctrl)
 {
@@ -111,21 +115,32 @@ static uint64_t percentile(uint32_t hundredths)
 	return retained[rank - 1U];
 }
 
-/*
- * Samples slower than the median.
+/* Samples disturbed enough to sit clear of the baseline, which for a
+ * kernel latency distribution is the median.
  *
- * For a kernel latency distribution the median is the baseline: the
- * operation costs the same on almost every run, and what matters is how
- * many runs were disturbed and by how much. Counting them says that
- * directly, where a standard error would only describe how precisely an
- * average of two different populations had been estimated.
+ * Merely exceeding the median is not enough: the counter resolution
+ * spreads the baseline over a few counts, so that would report about
+ * half the samples as outliers. Require a margin instead, relative so
+ * it holds across platforms, floored below for quantized distributions.
  */
 static size_t percentiles_outliers(void)
 {
 	uint64_t median = percentile(5000);
+	uint64_t margin = median / CONFIG_ZTEST_BENCHMARK_OUTLIER_MARGIN_DIV;
+	uint64_t threshold;
 	size_t count = 0;
 
-	while ((count < retained_count) && (retained[retained_count - 1 - count] > median)) {
+	/* A distribution spanning a couple of counts is at the counter
+	 * resolution, not above it. One count is not enough to exclude
+	 * it: the neighbouring count is exactly one away.
+	 */
+	if (margin < 2U) {
+		margin = 2U;
+	}
+
+	threshold = median + margin;
+
+	while ((count < retained_count) && (retained[retained_count - 1 - count] > threshold)) {
 		count++;
 	}
 

--- a/tests/benchmarks/interrupt_latency/src/benchmarks.c
+++ b/tests/benchmarks/interrupt_latency/src/benchmarks.c
@@ -790,6 +790,7 @@ ZTEST_BENCHMARK_MANUAL(interrupt, zli_entry_while_locked, NUM_ITERATIONS, NULL, 
 
 #ifdef CONFIG_INT_BENCH_SCENARIO_END_TO_END
 static volatile timing_t e2e_start;
+static volatile bool e2e_done;
 
 static void e2e_handler(void)
 {
@@ -812,7 +813,7 @@ static void e2e_waiter_entry(void *p1, void *p2, void *p3)
 		start = e2e_start;
 		record(i, timing_cycles_get(&start, &finish));
 
-		k_sem_give(&sync_sem);
+		e2e_done = true;
 	}
 }
 
@@ -839,10 +840,20 @@ ZTEST_BENCHMARK_MANUAL(interrupt, irq_to_thread, NUM_ITERATIONS, NULL, NULL)
 		bench_load_churn();
 		bench_load_pollute();
 
+		/* Spin rather than block: blocking would race the
+		 * interrupt, which can arrive while this thread is still
+		 * entering k_sem_take(), charging the woken thread for a
+		 * block that is immediately unwound.
+		 *
+		 * The waiter runs at a higher priority, so it preempts
+		 * this loop as soon as the ISR wakes it.
+		 */
+		e2e_done = false;
 		e2e_start = timing_counter_get();
 		bench_trigger();
 
-		k_sem_take(&sync_sem, K_FOREVER);
+		while (!e2e_done) {
+		}
 	}
 
 	k_thread_join(&waiter_thread, K_FOREVER);

--- a/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
+++ b/tests/benchmarks/interrupt_latency/src/trigger_sw_irq.c
@@ -242,6 +242,11 @@ void bench_trigger_alt(void)
 #include <soc/dport_reg.h>
 #define BENCH_FROM_CPU_REG DPORT_CPU_INTR_FROM_CPU_2_REG
 #define BENCH_FROM_CPU_BIT DPORT_CPU_INTR_FROM_CPU_2
+#elif defined(CONFIG_SOC_SERIES_ESP32S2)
+/* The register moved to the system peripheral but kept the old prefix */
+#include <soc/system_reg.h>
+#define BENCH_FROM_CPU_REG DPORT_CPU_INTR_FROM_CPU_2_REG
+#define BENCH_FROM_CPU_BIT DPORT_CPU_INTR_FROM_CPU_2
 #else
 #include <soc/system_reg.h>
 #define BENCH_FROM_CPU_REG SYSTEM_CPU_INTR_FROM_CPU_2_REG


### PR DESCRIPTION
Three fixes on top of the interrupt_latency series: the Espressif
sw-irq trigger did not compile on ESP32-S2, the outlier count reported
every sample above the median (about half of a quantized distribution,
and worse as resolution improved), and irq_to_thread raced the trigger
against k_sem_take() so the woken thread was charged for a block that
was started and immediately unwound.